### PR TITLE
devise:ストロングパラメータの設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,5 +4,5 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller? #nicknameのデータを登録できる様にする設定             
 
   def configure_permitted_parameters #ストロングパラメータ
-      devise_parameter_saniizer.permit(:sign_up, key: [:nickname])
+      devise_parameter_sanitizer.permit(:sign_up, key: [:nickname])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user! #ログインしていないユーザーはログイン要求ページに飛ぶ設定
+  before_action :configure_permitted_parameters, if: :devise_controller? #nicknameのデータを登録できる様にする設定             
+
+  def configure_permitted_parameters #ストロングパラメータ
+      devise_parameter_saniizer.permit(:sign_up, key: [:nickname])
+  end


### PR DESCRIPTION
# what
・application_controller.rbにbefore_action :configure_permitted_parameters,if: :deviescontroller?
  を設定
   def configure_permitted_parameters
         devise_parameter_sanitizer.permit(:sign_up,key:[:nickname])   
   end
# why
 ・設定しないとnicknameの入力が不正な値（パラメータ）として認識されてしまいnicknameカラムに
　 値を保存できない