### PR TITLE
add-message-model

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,6 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :body, presence: true,unless: :image
+end

--- a/db/migrate/20190816114939_create_messages.rb
+++ b/db/migrate/20190816114939_create_messages.rb
@@ -1,0 +1,12 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.text :body
+      t.text :image
+      t.references :user,null: false,foregin_key:true
+      t.references :group,null: false,foregin_key: true
+      
+      t.timestamps 
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190812115951) do
+ActiveRecord::Schema.define(version: 20190816114939) do
 
   create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20190812115951) do
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_members_on_group_id", using: :btree
     t.index ["user_id"], name: "index_members_on_user_id", using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text     "body",       limit: 65535
+    t.text     "image",      limit: 65535
+    t.integer  "user_id",                  null: false
+    t.integer  "group_id",                 null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# what 
メッセージ送信機能のモデル作成
マイグレーションファイルの作成
マイグレーションファイルにカラム情報を追加
マイグレーションファイルを実行してmessagesテーブルを作成
modelファイルにアソシエーションを定義・バリテーションの定義imageが空でも送信できる様に設定

# why

